### PR TITLE
Fix shaman color string

### DIFF
--- a/ShestakUI/Compatibility/Classic.lua
+++ b/ShestakUI/Compatibility/Classic.lua
@@ -34,7 +34,7 @@ LibClassicDurations:Register("ShestakUI")
 RAID_CLASS_COLORS.SHAMAN.r = 0
 RAID_CLASS_COLORS.SHAMAN.g = 0.44
 RAID_CLASS_COLORS.SHAMAN.b = 0.87
-RAID_CLASS_COLORS.SHAMAN.colorStr = "0070de"
+RAID_CLASS_COLORS.SHAMAN.colorStr = "ff0070de"
 
 ----------------------------------------------------------------------------------------
 --	Specialization Functions


### PR DESCRIPTION
Else for example in tooltips it shows `c|0070deNAME` instead of a shaman his/her name in the blue color.