### PR TITLE
fixing client version check

### DIFF
--- a/ShestakUI_Config/Options.lua
+++ b/ShestakUI_Config/Options.lua
@@ -3967,7 +3967,7 @@ end
 ----------------------------------------------------------------------------------------
 --	Button in GameMenuButton frame
 ----------------------------------------------------------------------------------------
-if WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC or WOW_PROJECT_MISTS_CLASSIC then
+if WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC or WOW_PROJECT_ID == WOW_PROJECT_MISTS_CLASSIC then
 	local function openGUI()
 		PlaySound(SOUNDKIT.IG_MAINMENU_OPTION)
 		HideUIPanel(GameMenuFrame)


### PR DESCRIPTION
Second condition is always true, forcing Era down the MoP/TBC path.  Discovered it when troubleshooting why the ShestakUI button was missing from the main menu.  I imagine this is the intended functionality.