### PR TITLE
fixing a few typos when calling methods off objects

### DIFF
--- a/ShestakUI/Modules/Skins/Blizzard_Vanilla/Communities.lua
+++ b/ShestakUI/Modules/Skins/Blizzard_Vanilla/Communities.lua
@@ -282,7 +282,7 @@ local function LoadSkin()
 		end)
 
 		t.MessageFrame:StripTextures()
-		t.MessageFrame.MessageScrollStripTextures()
+		t.MessageFrame.MessageScroll:StripTextures()
 
 		t.MessageFrame.MessageScroll:CreateBackdrop("Overlay")
 		t.MessageFrame.MessageScroll.backdrop:SetPoint("TOPLEFT", -4, 5)

--- a/ShestakUI/Modules/Skins/Blizzard_Vanilla/QuestLog.lua
+++ b/ShestakUI/Modules/Skins/Blizzard_Vanilla/QuestLog.lua
@@ -65,7 +65,7 @@ local function LoadSkin()
 		for i = 1, getn(QuestStrip) do
 			local object = _G[QuestStrip[i]]
 			if object then
-				objectStripTextures()
+				object:StripTextures()
 			end
 		end
 


### PR DESCRIPTION
Missing a couple of :'s when calling some methods.