### PR TITLE
Avoid protected-frame taint in combat

### DIFF
--- a/ShestakUI/Core/API.lua
+++ b/ShestakUI/Core/API.lua
@@ -379,6 +379,31 @@ local function FadeOut(f)
 	UIFrameFadeOut(f, 0.8, f:GetAlpha(), 0)
 end
 
+----------------------------------------------------------------------------------------
+--	Combat-safe RegisterForClicks
+----------------------------------------------------------------------------------------
+do
+	local pending = {}
+	local watcher
+	function T.RegisterClicks(frame, ...)
+		if not InCombatLockdown() then
+			frame:RegisterForClicks(...)
+			return
+		end
+		pending[frame] = {...}
+		if not watcher then
+			watcher = CreateFrame("Frame")
+			watcher:RegisterEvent("PLAYER_REGEN_ENABLED")
+			watcher:SetScript("OnEvent", function()
+				for f, args in next, pending do
+					f:RegisterForClicks(unpack(args))
+					pending[f] = nil
+				end
+			end)
+		end
+	end
+end
+
 local function addAPI(object)
 	local mt = getmetatable(object).__index
 	if not object.SetOutside then mt.SetOutside = SetOutside end

--- a/ShestakUI/Modules/Quests/AutoButton.lua
+++ b/ShestakUI/Modules/Quests/AutoButton.lua
@@ -48,7 +48,29 @@ AutoButtonAnchor:SetSize(40, 40)
 -- Create button
 local AutoButton = CreateFrame("Button", "AutoButton", UIParent, T.TBC and "InsecureActionButtonTemplate" or "SecureActionButtonTemplate")
 AutoButton:SetSize(40, 40)
-AutoButton:SetPoint("CENTER", AutoButtonAnchor, "CENTER", 0, 0)
+AutoButton:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
+
+-- AutoButton is protected, so it can't stay anchored to the mover: dragging the mover in
+-- combat would move a protected frame. Copy the mover's position onto UIParent instead.
+local function PinAutoButton()
+	if InCombatLockdown() then return end
+	local left, bottom = AutoButtonAnchor:GetLeft(), AutoButtonAnchor:GetBottom()
+	if not left or not bottom then return end
+
+	local scale = AutoButtonAnchor:GetEffectiveScale() / AutoButton:GetEffectiveScale()
+	AutoButton:ClearAllPoints()
+	AutoButton:SetPoint("BOTTOMLEFT", UIParent, "BOTTOMLEFT", left * scale, bottom * scale)
+end
+
+local function QueuePin() C_Timer.After(0, PinAutoButton) end
+QueuePin()
+hooksecurefunc(AutoButtonAnchor, "SetPoint", QueuePin)
+
+local pinFrame = CreateFrame("Frame")
+pinFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
+pinFrame:RegisterEvent("UI_SCALE_CHANGED")
+pinFrame:RegisterEvent("DISPLAY_SIZE_CHANGED")
+pinFrame:SetScript("OnEvent", QueuePin)
 AutoButton:SetTemplate("Default")
 AutoButton:StyleButton(true)
 AutoButton:RegisterForClicks("AnyUp", "AnyDown")

--- a/ShestakUI/Modules/UnitFrames/Layout.lua
+++ b/ShestakUI/Modules/UnitFrames/Layout.lua
@@ -24,7 +24,7 @@ local function Shared(self, unit)
 	self.colors = T.oUF_colors
 
 	-- Register click
-	self:RegisterForClicks("AnyUp")
+	T.RegisterClicks(self, "AnyUp")
 	self:SetScript("OnEnter", UnitFrame_OnEnter)
 	self:SetScript("OnLeave", UnitFrame_OnLeave)
 

--- a/ShestakUI/Modules/UnitFrames/RaidDPS.lua
+++ b/ShestakUI/Modules/UnitFrames/RaidDPS.lua
@@ -32,7 +32,7 @@ local function Shared(self, unit)
 	self.colors = T.oUF_colors
 
 	-- Register click
-	self:RegisterForClicks("AnyUp")
+	T.RegisterClicks(self, "AnyUp")
 	self:SetScript("OnEnter", UnitFrame_OnEnter)
 	self:SetScript("OnLeave", UnitFrame_OnLeave)
 

--- a/ShestakUI/Modules/UnitFrames/RaidHeal.lua
+++ b/ShestakUI/Modules/UnitFrames/RaidHeal.lua
@@ -35,7 +35,7 @@ local function Shared(self, unit)
 	self.colors = T.oUF_colors
 
 	-- Register click
-	self:RegisterForClicks("AnyUp")
+	T.RegisterClicks(self, "AnyUp")
 	self:SetScript("OnEnter", UnitFrame_OnEnter)
 	self:SetScript("OnLeave", UnitFrame_OnLeave)
 


### PR DESCRIPTION
Add T.RegisterClicks. this function registers the frame for clicks, but if you're in combat it will delay the registration until PLAYER_REGEN_ENABLED triggers (aka not in combat). 

also, AutoButton is a protected this just anchors it to the parent instead.